### PR TITLE
fix: [WLEO-291] Invalid JSON objects in decoded CBOR in Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -97,7 +97,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
   // IOWalletCBOR library
-  implementation("it.pagopa.io.wallet.cbor:cbor:1.0.1") {
+  implementation("it.pagopa.io.wallet.cbor:cbor:1.0.2") {
     exclude(group: "org.bouncycastle")
   }
   implementation 'org.bouncycastle:bcprov-jdk18on:1.77'

--- a/android/src/main/java/com/pagopa/ioreactnativecbor/IoReactNativeCborModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativecbor/IoReactNativeCborModule.kt
@@ -11,6 +11,7 @@ import it.pagopa.io.wallet.cbor.cose.COSEManager
 import it.pagopa.io.wallet.cbor.cose.FailureReason
 import it.pagopa.io.wallet.cbor.cose.SignWithCOSEResult
 import it.pagopa.io.wallet.cbor.parser.CBorParser
+import java.lang.RuntimeException
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 class IoReactNativeCborModule(reactContext: ReactApplicationContext) :
@@ -26,7 +27,7 @@ class IoReactNativeCborModule(reactContext: ReactApplicationContext) :
     val buffer = try {
       kotlin.io.encoding.Base64.decode(data)
     } catch (e: Exception) {
-      ModuleException.INVALID_ENCODING.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message ?: ""))
+      ModuleException.INVALID_ENCODING.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message.orEmpty()))
       return;
     }
 
@@ -37,7 +38,7 @@ class IoReactNativeCborModule(reactContext: ReactApplicationContext) :
         ModuleException.UNABLE_TO_DECODE.reject(promise)
       }
     } catch (e: Exception) {
-      ModuleException.UNKNOWN_EXCEPTION.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message ?: ""))
+      ModuleException.UNKNOWN_EXCEPTION.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message.orEmpty()))
     }
   }
 
@@ -47,20 +48,17 @@ class IoReactNativeCborModule(reactContext: ReactApplicationContext) :
     val buffer = try {
       kotlin.io.encoding.Base64.decode(data)
     } catch (e: Exception) {
-      ModuleException.INVALID_ENCODING.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message ?: ""))
+      ModuleException.INVALID_ENCODING.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message.orEmpty()))
       return;
     }
-
     try {
-      CBorParser(buffer).documentsCborToJson(true) { json ->
-        json?.let {
-          promise.resolve(it)
-        } ?: run {
-          ModuleException.UNABLE_TO_DECODE.reject(promise)
-        }
+      CBorParser(buffer).documentsCborToJson(separateElementIdentifier = true, onComplete = {
+        promise.resolve(it)
+      }) { ex ->
+        ModuleException.UNABLE_TO_DECODE.reject(promise, Pair(ERROR_USER_INFO_KEY, ex.message.orEmpty()))
       }
     } catch (e: Exception) {
-      ModuleException.UNKNOWN_EXCEPTION.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message ?: ""))
+      ModuleException.UNKNOWN_EXCEPTION.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message.orEmpty()))
     }
   }
 
@@ -70,7 +68,7 @@ class IoReactNativeCborModule(reactContext: ReactApplicationContext) :
     val data = try {
       kotlin.io.encoding.Base64.decode(payload)
     } catch (e: Exception) {
-      ModuleException.INVALID_ENCODING.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message ?: ""))
+      ModuleException.INVALID_ENCODING.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message.orEmpty()))
       return;
     }
 
@@ -104,7 +102,7 @@ class IoReactNativeCborModule(reactContext: ReactApplicationContext) :
         }
       }
     } catch (e: Exception) {
-      ModuleException.UNKNOWN_EXCEPTION.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message ?: ""))
+      ModuleException.UNKNOWN_EXCEPTION.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message.orEmpty()))
     }
   }
 
@@ -114,7 +112,7 @@ class IoReactNativeCborModule(reactContext: ReactApplicationContext) :
     val data = try {
       kotlin.io.encoding.Base64.decode(sign1Data)
     } catch (e: Exception) {
-      ModuleException.INVALID_ENCODING.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message ?: ""))
+      ModuleException.INVALID_ENCODING.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message.orEmpty()))
       return;
     }
 
@@ -125,7 +123,7 @@ class IoReactNativeCborModule(reactContext: ReactApplicationContext) :
       )
       promise.resolve(result)
     } catch (e: Exception) {
-      ModuleException.UNKNOWN_EXCEPTION.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message ?: ""))
+      ModuleException.UNKNOWN_EXCEPTION.reject(promise, Pair(ERROR_USER_INFO_KEY, e.message.orEmpty()))
     }
   }
 

--- a/android/src/main/java/com/pagopa/ioreactnativecbor/IoReactNativeCborModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativecbor/IoReactNativeCborModule.kt
@@ -11,7 +11,6 @@ import it.pagopa.io.wallet.cbor.cose.COSEManager
 import it.pagopa.io.wallet.cbor.cose.FailureReason
 import it.pagopa.io.wallet.cbor.cose.SignWithCOSEResult
 import it.pagopa.io.wallet.cbor.parser.CBorParser
-import java.lang.RuntimeException
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 class IoReactNativeCborModule(reactContext: ReactApplicationContext) :


### PR DESCRIPTION
## Short description
This PR fixes an issue with invalid JSON objects in the decoded CBOR in Android

## List of changes proposed in this pull request

- Update the underlying native implementation on Android;
- Use the `orEmpty()` function when sending the error message to the RN bridge.

## How to test
Try to decode a document and check if the decoded credential has valid JOSN objects in its claims.
