### PR TITLE
fix: [WLEO-395] Updated cbor native dependency to v1.2.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,7 +79,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
    // IOWalletCBOR library
-  implementation("it.pagopa.io.wallet.cbor:cbor:1.2.1") {
+  implementation("it.pagopa.io.wallet.cbor:cbor:1.2.2") {
     exclude(group: "org.bouncycastle")
   }
   // IOWalletProximity library


### PR DESCRIPTION
## Short description

Updated `it.pagopa.io.wallet.cbor:cbor` from `v1.2.1` to `v1.2.2`.

## List of changes proposed in this pull request

- `android/build.gradle` : Updated `it.pagopa.io.wallet.cbor:cbor` from `v1.2.1` to `v1.2.2`.

## How to test

Build the example app from scratch and test all the functionalities, more specifically check that the `age_over_18` claim is a boolean on `iOS` and the `verification.evidence` claim on `Android` is a correct `JSON`.