### PR TITLE
chore: [WLEO-399] Update Android native dependency to version 1.2.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,7 +79,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
    // IOWalletCBOR library
-  implementation("it.pagopa.io.wallet.cbor:cbor:1.2.2") {
+  implementation("it.pagopa.io.wallet.cbor:cbor:1.2.4") {
     exclude(group: "org.bouncycastle")
   }
   // IOWalletProximity library

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.78.2):
     - hermes-engine/Pre-built (= 0.78.2)
   - hermes-engine/Pre-built (0.78.2)
-  - IoReactNativeCbor (1.2.1):
+  - IoReactNativeCbor (1.2.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1799,7 +1799,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: 2771b98fb813fdc6f92edd7c9c0035ecabf9fee7
-  IoReactNativeCbor: 7599011d6a27b591513fa78ac62a282ba72357e8
+  IoReactNativeCbor: a5d98b1ba001c254dcd48d73df51278848b85b9d
   IOWalletCBOR: 016de622a863910c0ac6dab3356e1d1d3b272091
   IOWalletProximity: b0985f6b1b8d8b5b543d266fb37d719ac5cbfbce
   pagopa-io-react-native-crypto: b34250ee64b80d058320ee88233177df8d8d03b0


### PR DESCRIPTION
## Short description
This PR updates the native dependency to version `1.2.4` in order to lower the required Kotlin version to integrate it.

## List of changes proposed in this pull request
- Update `it.pagopa.io.wallet.cbor:cbor` to version `1.2.4`;  
- Update `Podfile.lock`.

## How to test
Test the example app scenarios for any regression.