### PR TITLE
chore(ios): [WLEO-402] bump IOWalletProximity to v1.0.1 and fix OID4VP deviceSignature

### DIFF
--- a/IoReactNativeCbor.podspec
+++ b/IoReactNativeCbor.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
     #IOWalletCBOR dependency
     s.dependency "IOWalletCBOR", "~> 0.0.9"
     #IOWalletProximity dependency
-    s.dependency "IOWalletProximity", "~> 0.0.6"
+    s.dependency "IOWalletProximity", "~> 1.0.1"
 
 # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
 # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - glog
     - hermes-engine
     - IOWalletCBOR (~> 0.0.9)
-    - IOWalletProximity (~> 0.0.6)
+    - IOWalletProximity (~> 1.0.1)
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
     - RCTTypeSafety
@@ -32,7 +32,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - IOWalletCBOR (0.0.9)
-  - IOWalletProximity (0.0.6)
+  - IOWalletProximity (1.0.1)
   - pagopa-io-react-native-crypto (1.0.1):
     - DoubleConversion
     - glog
@@ -1799,9 +1799,9 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: 2771b98fb813fdc6f92edd7c9c0035ecabf9fee7
-  IoReactNativeCbor: b6ed863496398cbf384b9d9f547f4a33f3e02e4a
+  IoReactNativeCbor: 6c48a91437e17efa612590007790177ed675b718
   IOWalletCBOR: 016de622a863910c0ac6dab3356e1d1d3b272091
-  IOWalletProximity: b0985f6b1b8d8b5b543d266fb37d719ac5cbfbce
+  IOWalletProximity: fed5a3163c70a81b032db0871542ff0bb03fca13
   pagopa-io-react-native-crypto: b34250ee64b80d058320ee88233177df8d8d03b0
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: be794de7dc6ed8f9f7fbf525f86e7651b8b68746

--- a/ios/IoReactNativeCbor.swift
+++ b/ios/IoReactNativeCbor.swift
@@ -141,12 +141,15 @@ class IoReactNativeCbor: NSObject {
       
       let items = try JSONDecoder().decode([String : [String : [String : Bool]]].self, from: Data(fieldRequestedAndAccepted.utf8))
       
-      guard let response = Proximity.shared.generateDeviceResponse(allowed: true, items: items, documents: documentsAsProximityDocument, sessionTranscript: sessionTranscript) else {
+      do {
+        let response = try Proximity.shared.generateDeviceResponse(allowed: true, items: items, documents: documentsAsProximityDocument, sessionTranscript: sessionTranscript)
+        resolve(Data(response).base64EncodedString())
+      } catch {
         ME.unableToGenerateResponse.reject(reject: reject)
         return
       }
       
-      resolve(Data(response).base64EncodedString())
+      
 
       
     } catch let error as NSError where error.domain == ME.invalidDocRequested.rawValue {


### PR DESCRIPTION
## Short description

This PR aims to solve the wrong deviceSignature when present remote credential for mdoc format. IOWalletProximity v1.0.1 brings the fix regarding how deviceSignature is created.

## List of changes proposed in this pull request

- `IoReactNativeCbor.podspec` and `example/ios/Podfile.lock` now require **IOWalletProximity** ~> **1.0.1** (was ~> 0.0.6).
- Replaced the old guard let … pattern with a do/try/catch, resolving the Base64-encoded response only on success and correctly rejecting on failure.

## How to test

Test the example app OID4VP Response scenarios for any regression.
