### PR TITLE
chore: [WLEO-429] Update proximity dependency

### DIFF
--- a/IoReactNativeCbor.podspec
+++ b/IoReactNativeCbor.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
     #IOWalletCBOR dependency
     s.dependency "IOWalletCBOR", "~> 0.1.0"
     #IOWalletProximity dependency
-    s.dependency "IOWalletProximity", "~> 1.0.1"
+    s.dependency "IOWalletProximity", "~> 1.2.1"
 
 # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
 # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     exclude(group: "org.bouncycastle")
   }
   // IOWalletProximity library
-  implementation("it.pagopa.io.wallet.proximity:proximity:1.3.0") {
+  implementation("it.pagopa.io.wallet.proximity:proximity:1.4.0") {
     exclude(group: "org.bouncycastle")
   }
   implementation 'org.bouncycastle:bcprov-jdk18on:1.77'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - glog
     - hermes-engine
     - IOWalletCBOR (~> 0.1.0)
-    - IOWalletProximity (~> 1.0.1)
+    - IOWalletProximity (~> 1.2.1)
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
     - RCTTypeSafety
@@ -32,7 +32,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - IOWalletCBOR (0.1.0)
-  - IOWalletProximity (1.0.1)
+  - IOWalletProximity (1.2.1)
   - pagopa-io-react-native-crypto (1.0.1):
     - DoubleConversion
     - glog
@@ -1799,9 +1799,9 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: 2771b98fb813fdc6f92edd7c9c0035ecabf9fee7
-  IoReactNativeCbor: 56454f6ec4809f68ad68ad66f300a4eb99f74154
+  IoReactNativeCbor: a2fc4ba344bb8f31c936f595a490a5834b639ddb
   IOWalletCBOR: f6147a29e88bfd3ef36386840df1b5f907c3ae41
-  IOWalletProximity: fed5a3163c70a81b032db0871542ff0bb03fca13
+  IOWalletProximity: 66db020e9570b5b14483090336a7cdc3b0418e7c
   pagopa-io-react-native-crypto: b34250ee64b80d058320ee88233177df8d8d03b0
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: be794de7dc6ed8f9f7fbf525f86e7651b8b68746

--- a/ios/IoReactNativeCbor.swift
+++ b/ios/IoReactNativeCbor.swift
@@ -142,7 +142,7 @@ class IoReactNativeCbor: NSObject {
       let items = try JSONDecoder().decode([String : [String : [String : Bool]]].self, from: Data(fieldRequestedAndAccepted.utf8))
       
       do {
-        let response = try Proximity.shared.generateDeviceResponse(allowed: true, items: items, documents: documentsAsProximityDocument, sessionTranscript: sessionTranscript)
+        let response = try Proximity.shared.generateDeviceResponse(items: items, documents: documentsAsProximityDocument, sessionTranscript: sessionTranscript)
         resolve(Data(response).base64EncodedString())
       } catch {
         ME.unableToGenerateResponse.reject(reject: reject)


### PR DESCRIPTION
## Short description
This PR updates the proximity dependency on both iOS and Android to avoid conflicts with other packages that declares it.
Include a summary of the changes.

## List of changes proposed in this pull request

- Update native proximity dependency on both iOS and Android.
- Update iOS bridge implementation according to the new proximity dependency;

## How to test
Reinstall pods by running `cd ios && bundler exec pod update && cd ..` and test the example app on both platforms.
